### PR TITLE
Add Carousel and additional examples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14493,6 +14493,12 @@
         }
       }
     },
+    "rollup-plugin-peer-deps-external": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz",
+      "integrity": "sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==",
+      "dev": true
+    },
     "rollup-plugin-postcss": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-postcss/-/rollup-plugin-postcss-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-dom": "^17.0.2",
     "rollup": "^2.69.1",
     "rollup-plugin-dts": "^4.2.0",
+    "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.2",
     "ts-jest": "^27.1.3",
     "typescript": "^4.6.2"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import resolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
 import typescript from '@rollup/plugin-typescript'
+import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import dts from 'rollup-plugin-dts'
 import postcss from 'rollup-plugin-postcss'
 
@@ -22,7 +23,7 @@ export default [
         sourcemap: true,
       },
     ],
-    plugins: [resolve(), commonjs(), typescript({ tsconfig: './tsconfig.json' }), postcss()],
+    plugins: [peerDepsExternal(), resolve(), commonjs(), typescript({ tsconfig: './tsconfig.json' }), postcss()],
   },
   {
     input: 'dist/esm/types/index.d.ts',

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -1,0 +1,1 @@
+export * from './block'

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -10,7 +10,7 @@ export interface CardBaseProps extends HTMLAttributes<HTMLOrSVGElement> {
 export interface CardHeaderIconProps extends HTMLAttributes<HTMLOrSVGElement> {
   className?: string
   children?: React.ReactNode
-  onClick?: () => void
+  onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void
 }
 
 export const CardHeaderIcon: FC<CardHeaderIconProps> = ({ children, onClick, ...props }) => {

--- a/src/components/carousel/carousel.css
+++ b/src/components/carousel/carousel.css
@@ -1,0 +1,37 @@
+.is-multi-carousel {
+  overflow: hidden;
+}
+.is-multi-carousel .is-multi-carousel-inner {
+  transition: 1s ease all;
+}
+
+.is-multi-carousel .left-next,
+.is-multi-carousel .right-next {
+  position: absolute;
+  border-radius: 50%;
+  top: calc(50% - 20px);
+}
+.is-multi-carousel .left-next {
+  left: 0;
+}
+.is-multi-carousel .right-next {
+  right: 0;
+}
+
+.is-multi-carousel .leftLst.over,
+.is-multi-carousel .rightLst.over {
+  pointer-events: none;
+  background: #ccc;
+}
+.has-border {
+  margin: 5rem;
+  border: 1px solid black;
+  min-height: 300px;
+}
+
+.is-multi-carousel .is-multi-carousel-inner .column div {
+  min-height: 300px;
+}
+
+.is-multi-carousel .is-multi-carousel-inner {
+}

--- a/src/components/carousel/carousel.stories.tsx
+++ b/src/components/carousel/carousel.stories.tsx
@@ -118,5 +118,5 @@ const ShowMultipleSlidesTemplate: ComponentStory<typeof Carousel> = (args) => (
 export const ShowMultipleSlidesExample = ShowMultipleSlidesTemplate.bind({})
 // More on args: https://storybook.js.org/docs/react/writing-stories/args
 ShowMultipleSlidesExample.args = {
-  slidesToShow: 1,
+  slidesToShow: 2,
 }

--- a/src/components/carousel/carousel.stories.tsx
+++ b/src/components/carousel/carousel.stories.tsx
@@ -1,0 +1,122 @@
+import React from 'react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+
+import { Carousel, CarouselItem } from './carousel'
+
+import { Hero, Image } from '..'
+
+import './stories.css'
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+export default {
+  title: 'Example/Multi Carousel',
+  component: Carousel,
+} as ComponentMeta<typeof Carousel>
+
+// More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
+const Template: ComponentStory<typeof Carousel> = (args) => (
+  <Carousel>
+    <CarouselItem>
+      <div>The First Slide</div>
+    </CarouselItem>
+    <CarouselItem>
+      <div>The Second Slide</div>
+    </CarouselItem>
+    <CarouselItem>
+      <div>The Third Slide</div>
+    </CarouselItem>
+    <CarouselItem>
+      <div>The Fourth Slide</div>
+    </CarouselItem>
+  </Carousel>
+)
+
+export const Primary = Template.bind({})
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+Primary.args = {
+  children: 'Carousel Text',
+}
+
+const HeroSlidesTemplate: ComponentStory<typeof Carousel> = (args) => (
+  <Carousel>
+    <CarouselItem>
+      <Hero isInfo>A Hero Slide</Hero>
+    </CarouselItem>
+    <CarouselItem>
+      <Hero isDanger>Another Hero Slide</Hero>
+    </CarouselItem>
+    <CarouselItem>
+      <Hero className="hero-bg">Background Image</Hero>
+    </CarouselItem>
+    <CarouselItem>
+      <Image src="https://placedog.net/1200/210" alt="dogs" />
+    </CarouselItem>
+  </Carousel>
+)
+
+export const HeroSlidesExample = HeroSlidesTemplate.bind({})
+
+const AutoplayTemplate: ComponentStory<typeof Carousel> = (args) => (
+  <Carousel autoplay duration={args.duration}>
+    <CarouselItem>
+      <Hero isInfo>A Hero Slide</Hero>
+    </CarouselItem>
+    <CarouselItem>
+      <Hero isDanger>Another Hero Slide</Hero>
+    </CarouselItem>
+    <CarouselItem>
+      <Hero className="hero-bg">Background Image</Hero>
+    </CarouselItem>
+    <CarouselItem>
+      <Image src="https://placedog.net/1200/210" alt="dogs" />
+    </CarouselItem>
+  </Carousel>
+)
+
+export const AutoplayExample = AutoplayTemplate.bind({})
+AutoplayExample.args = {
+  duration: 8000,
+}
+
+const ShowMultipleSlidesTemplate: ComponentStory<typeof Carousel> = (args) => (
+  <Carousel slidesToShow={args.slidesToShow}>
+    <CarouselItem>
+      <Hero isInfo>The First Slide</Hero>
+    </CarouselItem>
+    <CarouselItem>
+      <Hero isPrimary>The Second Slide</Hero>
+    </CarouselItem>
+    <CarouselItem>
+      <Hero className="hero-bg">The Third Slide</Hero>
+    </CarouselItem>
+    <CarouselItem>
+      <Hero isLink>The Fourth Slide</Hero>
+    </CarouselItem>
+    <CarouselItem>
+      <Hero isDanger>The Fifth Slide</Hero>
+    </CarouselItem>
+    <CarouselItem>
+      <Hero isBold>The Sixth Slide</Hero>
+    </CarouselItem>
+    <CarouselItem>
+      <Hero isDark>The Seventh Slide</Hero>
+    </CarouselItem>
+    <CarouselItem>
+      <Hero isWarning>The Eighth Slide</Hero>
+    </CarouselItem>
+    <CarouselItem>
+      <Hero>The Ninth Slide</Hero>
+    </CarouselItem>
+    <CarouselItem>
+      <Hero>The Tenth Slide</Hero>
+    </CarouselItem>
+    <CarouselItem>
+      <Hero>The Eleventh Slide</Hero>
+    </CarouselItem>
+  </Carousel>
+)
+
+export const ShowMultipleSlidesExample = ShowMultipleSlidesTemplate.bind({})
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+ShowMultipleSlidesExample.args = {
+  slidesToShow: 1,
+}

--- a/src/components/carousel/carousel.stories.tsx
+++ b/src/components/carousel/carousel.stories.tsx
@@ -8,7 +8,7 @@ import { Hero, Image } from '..'
 import './stories.css'
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
-  title: 'Example/Multi Carousel',
+  title: 'Example/Carousel',
   component: Carousel,
 } as ComponentMeta<typeof Carousel>
 

--- a/src/components/carousel/carousel.tsx
+++ b/src/components/carousel/carousel.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useRef, useState, FC, useLayoutEffect } from 'react'
+import classnames from 'classnames'
+import { Screens } from '../../utils/modifiers'
+import { Button } from '../button'
+import { Icon } from '../icon'
+import './carousel.css'
+
+export interface CarouselBaseProps {
+  className?: string
+}
+export type CarouselItemProps = CarouselBaseProps
+export const CarouselItem: FC<CarouselItemProps> = ({ children, className }) => {
+  return <div className={classnames('column', className)}>{children}</div>
+}
+
+export interface CarouselProps extends CarouselBaseProps {
+  isMobile?: boolean
+  isFluid?: boolean
+  isWideScreen?: boolean
+  isFullHD?: boolean
+  hasBorder?: boolean
+  autoplay?: boolean
+  duration?: number
+  slidesToShow?: number
+}
+export const Carousel: FC<CarouselProps> = ({
+  children,
+  isMobile,
+  isFluid,
+  isWideScreen,
+  isFullHD,
+  hasBorder,
+  className,
+  autoplay,
+  duration = 10000,
+  slidesToShow = 1,
+}) => {
+  const classes = Screens({ isMobile, isFluid, isWideScreen, isFullHD })
+  const innerContainer = useRef<HTMLDivElement>()
+  const childrenAsArray = React.Children.toArray(children)
+  const totalSlides = childrenAsArray.length
+
+  const calcSlideClass = (show: number) => {
+    let isStyle = 'is-12'
+    switch (show) {
+      case 1:
+        isStyle = 'is-12'
+        break
+      case 2:
+        isStyle = 'is-6'
+        break
+      case 3:
+        isStyle = 'is-4'
+        break
+      case 4:
+        isStyle = 'is-3'
+        break
+      default:
+        isStyle = 'is-12'
+        break
+    }
+    return isStyle
+  }
+
+  const kids = childrenAsArray.map((child, i) =>
+    React.isValidElement(child)
+      ? React.cloneElement(child, {
+          className: calcSlideClass(slidesToShow),
+        })
+      : child
+  )
+
+  const [carouselOffsest, setCarouselOffsest] = useState(0)
+
+  useEffect(() => {
+    if (innerContainer.current) {
+      const total = parseFloat(
+        getComputedStyle(innerContainer.current, null).width.replace('px', '')
+      )
+      const currentOffset = total * (1 * carouselOffsest)
+      innerContainer.current.style.transform = `translateX(-${currentOffset}px)`
+    }
+  })
+
+  useEffect(() => {
+    if (autoplay) {
+      const timer = setInterval(() => {
+        if (carouselOffsest < totalSlides - 1) {
+          setCarouselOffsest(carouselOffsest + 1)
+        } else {
+          setCarouselOffsest(0)
+        }
+      }, duration)
+
+      // clearing interval
+      return () => clearInterval(timer)
+    }
+  })
+
+  return (
+    <div className={classnames('container', { 'has-border': hasBorder })}>
+      <div className={classnames('is-multi-carousel', className, classes)}>
+        <div className="is-multi-carousel-inner columns is-variable" ref={innerContainer}>
+          {kids}
+        </div>
+        <Button
+          className="left-next"
+          onClick={(e) => {
+            e.preventDefault()
+            if (carouselOffsest > 0) {
+              setCarouselOffsest(carouselOffsest - 1)
+            }
+          }}
+        >
+          <Icon icon="chevron-left" fas />
+        </Button>
+        <Button
+          className="right-next"
+          onClick={(e) => {
+            e.preventDefault()
+            if (slidesToShow > 1) {
+              const totalBlocks = Math.ceil(totalSlides / slidesToShow)
+              if (carouselOffsest < totalBlocks - 1) {
+                setCarouselOffsest(carouselOffsest + 1)
+              } else {
+                setCarouselOffsest(0)
+              }
+            } else if (carouselOffsest < totalSlides - 1) {
+              setCarouselOffsest(carouselOffsest + 1)
+            } else {
+              setCarouselOffsest(0)
+            }
+          }}
+        >
+          <Icon icon="chevron-right" fas />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+Carousel.defaultProps = {
+  className: '',
+  isMobile: false,
+  isFluid: false,
+  isWideScreen: false,
+  isFullHD: false,
+}

--- a/src/components/carousel/stories.css
+++ b/src/components/carousel/stories.css
@@ -1,0 +1,10 @@
+.hero-bg {
+  background-image: url(https://placedog.net/1920/300);
+  background: linear-gradient(rgba(31, 44, 108, 0.65), rgba(31, 44, 108, 0.65)),
+    rgba(0, 0, 0, 0.55) url('https://placedog.net/1920/300') no-repeat;
+  background-attachment: fixed;
+  background-size: cover;
+  color: white;
+  box-shadow: inset 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
+  font-family: 'Poppins', sans-serif;
+}

--- a/src/components/collapse/collapse.stories.tsx
+++ b/src/components/collapse/collapse.stories.tsx
@@ -1,0 +1,215 @@
+import React, { FC } from 'react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+
+import { Collapse } from './collapse'
+import { useToggle } from '../../hooks'
+import {
+  Block,
+  Button,
+  Card,
+  CardBody,
+  CardFooter,
+  CardFooterItem,
+  CardHeader,
+  CardHeaderIcon,
+  Column,
+  Columns,
+  Content,
+  Control,
+  Icon,
+  Panel,
+  PanelBlock,
+  PanelTabs,
+} from '../'
+
+const Demo: FC = () => {
+  const [shown, toggle] = useToggle(false)
+  return (
+    <div>
+      <Collapse isShown={shown}>
+        Primar lorem ipsum dolor sit amet, consectetur adipiscing elit lorem ipsum dolor.{' '}
+        <strong>Pellentesque risus mi</strong>, tempus quis placerat ut, porta nec nulla. Vestibulum
+        rhoncus ac ex sit amet fringilla. Nullam gravida purus diam, et dictum{' '}
+        <a>felis venenatis</a> efficitur. Sit amet, consectetur adipiscing elit
+      </Collapse>
+      {!shown && (
+        <button
+          className="button"
+          onClick={(e) => {
+            toggle()
+          }}
+        >
+          Show
+        </button>
+      )}
+      {shown && (
+        <button
+          className="button"
+          onClick={(e) => {
+            toggle()
+          }}
+        >
+          Hide
+        </button>
+      )}
+    </div>
+  )
+}
+
+const PanelDemo: FC = () => {
+  const [shown, toggle] = useToggle(false)
+  return (
+    <>
+      <Block>
+        {!shown && (
+          <Button
+            onClick={(e) => {
+              toggle()
+            }}
+          >
+            Show
+          </Button>
+        )}
+        {shown && (
+          <Button
+            onClick={(e) => {
+              toggle()
+            }}
+          >
+            Hide
+          </Button>
+        )}
+      </Block>
+      <Panel heading="repositories">
+        <PanelBlock>
+          <Control hasIconsLeft>
+            <input className="input is-small" type="text" placeholder="search" />
+            <Icon isSmall isLeft fas icon="search"></Icon>
+          </Control>
+        </PanelBlock>
+
+        <Collapse isPrimary isShown={shown}>
+          <PanelTabs>
+            <a className="is-active">all</a>
+            <a>public</a>
+            <a>private</a>
+            <a>sources</a>
+            <a>forks</a>
+          </PanelTabs>
+          <PanelBlock as="a" isActive>
+            <Icon iconClassName="panel-icon" fas icon="book"></Icon>
+            bulma
+          </PanelBlock>
+          <PanelBlock as="a">
+            <Icon iconClassName="panel-icon" fas icon="book"></Icon>
+            marksheet
+          </PanelBlock>
+          <PanelBlock as="a">
+            <Icon iconClassName="panel-icon" fas icon="book"></Icon>
+            minireset.css
+          </PanelBlock>
+          <PanelBlock as="a">
+            <Icon iconClassName="panel-icon" fas icon="book"></Icon>
+            jgthms.github.io
+          </PanelBlock>
+          <PanelBlock as="a">
+            <Icon iconClassName="panel-icon" fas icon="code-branch"></Icon>
+            daniellowtw/infboard
+          </PanelBlock>
+          <PanelBlock as="a">
+            <Icon iconClassName="panel-icon" fas icon="code-branch"></Icon>
+            mojs
+          </PanelBlock>
+          <PanelBlock as="label">
+            <input type="checkbox"></input>
+            remember me
+          </PanelBlock>
+          <PanelBlock>
+            <Button isLink isOutlined isFullWidth>
+              reset all filters
+            </Button>
+          </PanelBlock>
+        </Collapse>
+      </Panel>
+    </>
+  )
+}
+
+const CardDemo: FC = () => {
+  const [shown, toggle] = useToggle(true)
+  return (
+    <Columns>
+      <Column isOneThird>
+        <Card>
+          <CardHeader title="Component">
+            <CardHeaderIcon
+              onClick={(e) => {
+                e.preventDefault()
+                toggle()
+              }}
+            >
+              <Icon icon={shown ? 'angle-down' : 'angle-up'} fas />
+            </CardHeaderIcon>
+          </CardHeader>
+          <Collapse isShown={shown}>
+            <CardBody>
+              <Content>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus nec iaculis
+                mauris.
+                <a href="#">@bulmaio</a>. <a href="#">#css</a> <a href="#">#responsive</a>
+                <br />
+                <time dateTime="2016-1-1">11:09 PM - 1 Jan 2016</time>
+              </Content>
+            </CardBody>
+            <CardFooter>
+              <CardFooterItem>
+                <a
+                  href="#"
+                  onClick={(e) => {
+                    console.info('clicked')
+                    e.preventDefault()
+                  }}
+                >
+                  Save
+                </a>
+              </CardFooterItem>
+              <CardFooterItem>
+                <a href="#">Edit</a>
+              </CardFooterItem>
+              <CardFooterItem>
+                <a href="#">Delete</a>
+              </CardFooterItem>
+            </CardFooter>
+          </Collapse>
+        </Card>
+      </Column>
+    </Columns>
+  )
+}
+
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+export default {
+  title: 'Example/Collapse',
+  component: Collapse,
+  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
+  argTypes: {},
+} as ComponentMeta<typeof Collapse>
+
+// More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
+const Template: ComponentStory<typeof Collapse> = (args) => <Demo />
+
+export const CollapseExample = Template.bind({})
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+CollapseExample.args = {}
+
+const PanelTemplate: ComponentStory<typeof Collapse> = (args) => <PanelDemo />
+
+export const PanelExample = PanelTemplate.bind({})
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+PanelExample.args = {}
+
+const CardTemplate: ComponentStory<typeof Collapse> = (args) => <CardDemo />
+
+export const CardExample = CardTemplate.bind({})
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+CardExample.args = {}

--- a/src/components/collapse/collapse.tsx
+++ b/src/components/collapse/collapse.tsx
@@ -1,26 +1,35 @@
-import React, {  useEffect, useRef, forwardRef, ElementType, HTMLAttributes, FC, ComponentProps  } from 'react'
+import React, {
+  useEffect,
+  useRef,
+  forwardRef,
+  ElementType,
+  HTMLAttributes,
+  FC,
+  ComponentProps,
+} from 'react'
 import classnames from 'classnames'
 import { BaseElement } from '../base-element'
+import { ColorProps } from '../../utils'
 
-export interface CollapseProps extends HTMLAttributes<HTMLOrSVGElement>  {
-    className?: string
-    isShown?: boolean
-    children?: React.ReactNode
-    animationIn?: string
-    animationOut?: string
-    onClick?: () => void;
-  }
+export interface CollapseProps extends HTMLAttributes<HTMLOrSVGElement> {
+  className?: string
+  isShown?: boolean
+  children?: React.ReactNode
+  animationIn?: string
+  animationOut?: string
+  onClick?: () => void
+}
 
-  export interface AnimationProps   {
-    target: HTMLElement
-    animationName: string
-  }
+export interface AnimationProps {
+  target: HTMLElement
+  animationName: string
+}
 const defaultProps = {
-    isShown: true,
-    animationIn: 'fadeIn',
-    animationOut: 'fadeOut',
-  }
-export const Collapse: FC<CollapseProps> = ({
+  isShown: true,
+  animationIn: 'fadeIn',
+  animationOut: 'fadeOut',
+}
+export const Collapse: FC<CollapseProps & ColorProps> = ({
   className,
   children,
   isShown,
@@ -39,16 +48,15 @@ export const Collapse: FC<CollapseProps> = ({
   }
 
   useEffect(() => {
-    
-    const onEnd = ({ target, animationName }:AnimationEvent) => {
-        const castTarget = target as HTMLElement
+    const onEnd = ({ target, animationName }: AnimationEvent) => {
+      const castTarget = target as HTMLElement
       if (castTarget && animationName.indexOf('Out') > -1) {
         castTarget.classList.add('is-hidden')
       }
     }
-    const onStart = ({ target  }:AnimationEvent) => {
-        const castTarget = target as HTMLElement
-        castTarget.classList.remove('is-hidden')
+    const onStart = ({ target }: AnimationEvent) => {
+      const castTarget = target as HTMLElement
+      castTarget.classList.remove('is-hidden')
     }
     if (container && container.current) {
       container.current.addEventListener('animationend', onEnd)
@@ -61,10 +69,7 @@ export const Collapse: FC<CollapseProps> = ({
   }, [isShown])
 
   return (
-    <div
-      className={classnames('collapsed', className, animation)}
-      {...props}
-    >
+    <div className={classnames('collapsed', className, animation)} {...props}>
       {children}
     </div>
   )
@@ -73,9 +78,3 @@ export const Collapse: FC<CollapseProps> = ({
 Collapse.defaultProps = defaultProps
 
 export default Collapse
-
-
-
-
-
-

--- a/src/components/columns/columns.tsx
+++ b/src/components/columns/columns.tsx
@@ -1,7 +1,7 @@
-import React, { ElementType, FC, ReactNode } from 'react'
+import React, { ElementType, FC, ReactNode, HTMLAttributes } from 'react'
 import classnames from 'classnames'
 
-export interface ColumnsProps {
+export interface ColumnsProps extends HTMLAttributes<HTMLOrSVGElement> {
   children?: React.ReactNode
   className?: string
   isMobile?: boolean
@@ -18,6 +18,7 @@ export const Columns: FC<ColumnsProps> = ({
   isCentered,
   isNarrow,
   isGapless,
+  ...props
 }) => {
   const classes = {
     'is-mobile': isMobile,
@@ -27,7 +28,11 @@ export const Columns: FC<ColumnsProps> = ({
     'is-gapless': isGapless,
   }
 
-  return <div className={classnames('columns', className, classes)}>{children}</div>
+  return (
+    <div className={classnames('columns', className, classes)} {...props}>
+      {children}
+    </div>
+  )
 }
 Columns.defaultProps = {
   className: '',
@@ -38,7 +43,7 @@ Columns.defaultProps = {
   isGapless: false,
 }
 
-export interface ColumnProps {
+export interface ColumnProps extends HTMLAttributes<HTMLOrSVGElement> {
   as?: ElementType
   children?: ReactNode
   className?: string
@@ -60,6 +65,7 @@ export interface ColumnProps {
   isOffsetHalf?: boolean
   isOffsetOneThird?: boolean
   isHidden?: boolean
+  isFullheight?: boolean
   offset?: '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | null
   size?: '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' | null
 }
@@ -86,6 +92,8 @@ export const Column: FC<ColumnProps> = ({
   offset,
   size,
   is,
+  isFullheight,
+  ...props
 }) => {
   const classes = {
     'is-four-fifths': isFourFifths,
@@ -127,6 +135,7 @@ export const Column: FC<ColumnProps> = ({
     'is-offset-9': false,
     'is-offset-10': false,
     'is-offset-11': false,
+    'is-full-height': isFullheight,
   }
   if (size) {
     classes[`is-${size}`] = true
@@ -140,7 +149,11 @@ export const Column: FC<ColumnProps> = ({
   if (size && is) {
     console.warn('Do not use both size and is')
   }
-  return <Col className={classnames('column', className, classes)}>{children}</Col>
+  return (
+    <Col className={classnames('column', className, classes)} {...props}>
+      {children}
+    </Col>
+  )
 }
 
 Column.defaultProps = {

--- a/src/components/container/container.tsx
+++ b/src/components/container/container.tsx
@@ -10,6 +10,7 @@ export interface ContainerProps {
   isFluid?: boolean
   isWideScreen?: boolean
   isFullHD?: boolean
+  hasTextCentered?: boolean
 }
 export const Container: FC<ContainerProps> = ({ className, children, ...props }) => {
   return (

--- a/src/components/icon/icon.stories.tsx
+++ b/src/components/icon/icon.stories.tsx
@@ -22,3 +22,29 @@ DefaultIcon.args = {
   icon: 'home',
   fa: true,
 }
+export const ChevronRightIcon = Template.bind({})
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+ChevronRightIcon.args = {
+  icon: 'chevron-right',
+  fa: true,
+}
+
+export const ChevronLeftIcon = Template.bind({})
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+ChevronLeftIcon.args = {
+  icon: 'chevron-left',
+  fa: true,
+}
+
+export const CogIcon = Template.bind({})
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+CogIcon.args = {
+  icon: 'cog',
+  fa: true,
+}
+export const CogsIcon = Template.bind({})
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+CogsIcon.args = {
+  icon: 'cogs',
+  fas: true,
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from './autocomplete'
 export * from './base-element'
+export * from './block'
 export * from './box'
 export * from './breadcrumb'
 export * from './button'

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -132,7 +132,7 @@ export interface NavProps {
   className?: string
 }
 export interface NavBarMenuProps {
-  id: string
+  id?: string
   isActive?: boolean
 }
 export const NavBarStart: FC<NavProps> = ({ children, className }) => {

--- a/src/stories/inbox.stories.tsx
+++ b/src/stories/inbox.stories.tsx
@@ -1,9 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import classnames from 'classnames'
-import { useStyleSheet } from '@brightleaf/react-hooks/lib/use-stylesheet'
-import { useScript } from '@brightleaf/react-hooks/lib/use-script'
-import { useGet } from '@brightleaf/react-hooks/lib/use-get'
-
+import { useStyleSheet, useScript, useGet } from '@brightleaf/react-hooks'
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import {


### PR DESCRIPTION
This Pull request adds the first cut of a carousel component and examples of it in action. Additionally, I added more examples of the collapse component in action

## Carousel

![Screen Shot 2022-03-13 at 2 11 48 PM](https://user-images.githubusercontent.com/62547/158040646-0c12f5e9-a8de-4e99-a72f-0bcd6195dbf8.png)
![Screen Shot 2022-03-13 at 2 11 43 PM](https://user-images.githubusercontent.com/62547/158040651-9cfcc2b6-c258-41a6-86c3-574f0b48dcbd.png)
![Screen Shot 2022-03-13 at 2 11 33 PM](https://user-images.githubusercontent.com/62547/158040653-7e567658-0b31-4e5d-aeec-2d7f24b9e132.png)

## Collapse Examples
![Screen Shot 2022-03-13 at 2 11 05 PM](https://user-images.githubusercontent.com/62547/158040655-8c058e8a-1f91-4ca9-9a24-af037413fe41.png)
![Screen Shot 2022-03-13 at 2 11 01 PM](https://user-images.githubusercontent.com/62547/158040656-8ee9e605-d324-431c-ad83-49b13a3e1481.png)
![Screen Shot 2022-03-13 at 2 10 52 PM](https://user-images.githubusercontent.com/62547/158040657-0c5c871e-142e-429f-bf52-d0609bc42ed7.png)
n